### PR TITLE
Fix onNetworkChange parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aptos-labs/wallet-adapter-core": "^2.2.0",
+        "@aptos-labs/wallet-adapter-core": "^2.5.0",
         "aptos": "^1.4.0"
       },
       "devDependencies": {
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@aptos-labs/wallet-adapter-core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-2.2.0.tgz",
-      "integrity": "sha512-JL0zTXXoSQba1EDGqY5yTJxZVKMKwgMKZNA1JyV54s5loWzE2tinwg002EB+ONodkVmMhKbWnajCFFOgvgk+NQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-2.5.0.tgz",
+      "integrity": "sha512-+OFQ51vdsBzYu9U281yvuOTaj/Qbo3D26ai3m+S0vKX2QdaDSMlpzDPz1NHVNU4nJnq0yk2ukfIA5fq2FgTPeA==",
       "dependencies": {
         "aptos": "^1.3.17",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aptos-labs/wallet-adapter-core": "^2.2.0",
+    "@aptos-labs/wallet-adapter-core": "^2.5.0",
     "aptos": "^1.4.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,13 +134,7 @@ export class PetraWallet implements AdapterPlugin {
         name,
         chainId,
         url,
-      }: {
-        name?: NetworkName;
-        chainId?: number;
-        url?: string;
-        // TODO: Unused. Delete once types in `wallet-adapter-core` are updated
-        networkName: NetworkInfo;
-      }): Promise<void> => {
+      }: NetworkInfo): Promise<void> => {
         callback({
           name,
           chainId,


### PR DESCRIPTION
# Description

`wallet-adapter-core` defines an incorrect type for `handleNetworkChange` because [`networkName` is unused in `WalletCore`](https://github.com/aptos-labs/aptos-wallet-adapter/blob/b0586e8c8b6c68847a29518781e5e8619cb23332/packages/wallet-adapter-core/src/WalletCore.ts#L402C3-L402C3) when the network changes.

# Test Plan

Link this package to the nextjs example project in `aptos-wallet-adapter` and check that the network properly changes

https://github.com/aptos-labs/petra-plugin-wallet-adapter/assets/8957844/e6cadb6c-7598-4ea2-9b58-a5042b34b71d

## Tests + Build

```
[nix-shell:~/aptos/petra-plugin-wallet-adapter]$ npm run test

> petra-plugin-wallet-adapter@0.1.5 test
> jest

 PASS  src/__tests__/index.test.ts
  PetraWallet
    ✓ defines name (1 ms)
    ✓ defines url
    ✓ defines icon
    ✓ defines connect()
    ✓ defines account()
    ✓ defines disconnect()
    ✓ defines signAndSubmitTransaction()
    ✓ defines signAndSubmitBCSTransaction()
    ✓ defines signMessage()
    ✓ defines signTransaction()
    ✓ defines onNetworkChange()
    ✓ defines onAccountChange()
    ✓ defines network()

Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        0.879 s
Ran all test suites.

[nix-shell:~/aptos/petra-plugin-wallet-adapter]$ npm run build

> petra-plugin-wallet-adapter@0.1.5 build
> tsup src/index.ts --format esm,cjs --dts

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v6.5.0
CLI Target: node14
ESM Build start
CJS Build start
ESM dist/index.mjs 6.15 KB
ESM ⚡️ Build success in 91ms
CJS dist/index.js 7.17 KB
CJS ⚡️ Build success in 91ms
DTS Build start
DTS ⚡️ Build success in 620ms
DTS dist/index.d.ts 3.34 KB
```
