### PR TITLE
Error fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "petra-plugin-wallet-adapter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "petra-plugin-wallet-adapter",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "petra-plugin-wallet-adapter",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "petra-plugin-wallet-adapter",
-      "version": "0.4.2",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "petra-plugin-wallet-adapter",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "petra-plugin-wallet-adapter",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petra-plugin-wallet-adapter",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "description": "Petra plugin to use with Aptos Wallet Adapter",
   "author": "Petra Aptos",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petra-plugin-wallet-adapter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Petra plugin to use with Aptos Wallet Adapter",
   "author": "Petra Aptos",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petra-plugin-wallet-adapter",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Petra plugin to use with Aptos Wallet Adapter",
   "author": "Petra Aptos",
   "main": "./dist/index.js",

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -8,7 +8,7 @@ import {
   Serializable as SerializableV2,
   generateTransactionPayload
 } from "@aptos-labs/ts-sdk";
-import { areBCSArguments, NetworkInfo } from '@aptos-labs/wallet-adapter-core';
+import { NetworkInfo } from '@aptos-labs/wallet-adapter-core';
 import { BCS, TxnBuilderTypes, Types } from "aptos";
 
 export type SerializableV1 = { serialize(serializer: BCS.Serializer): void };
@@ -64,19 +64,15 @@ export function convertV2JsonPayloadToV1(
   };
 }
 
-export async function convertV2PayloadToV1Payload(
+export async function generateV1TransactionPayload(
   payloadData: InputGenerateTransactionPayloadData, network: NetworkInfo,
-): Promise<Types.TransactionPayload | TxnBuilderTypes.TransactionPayload> {
-  // first check if each argument is a BCS serialized argument
-  if (areBCSArguments(payloadData.functionArguments)) {
-    const aptosConfig = new AptosConfig({
-      network: convertNetwork(network),
-    });
-    const newPayload = await generateTransactionPayload({
-      ...(payloadData as InputEntryFunctionDataWithRemoteABI),
-      aptosConfig: aptosConfig,
-    });
-    return convertV2toV1(newPayload, TxnBuilderTypes.TransactionPayload);
-  }
-  return convertV2JsonPayloadToV1(payloadData);
+): Promise<TxnBuilderTypes.TransactionPayload> {
+  const aptosConfig = new AptosConfig({
+    network: convertNetwork(network),
+  });
+  const newPayload = await generateTransactionPayload({
+    ...(payloadData as InputEntryFunctionDataWithRemoteABI),
+    aptosConfig: aptosConfig,
+  });
+  return convertV2toV1(newPayload, TxnBuilderTypes.TransactionPayload);
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,42 @@
+export class PetraApiError extends Error {
+  constructor(
+    readonly code: number,
+    readonly status: string,
+    message: string,
+  ) {
+    super(message);
+    this.status = status;
+    this.code = code;
+    Object.setPrototypeOf(this, PetraApiError.prototype);
+  }
+}
+
+export const PetraApiErrors = Object.freeze({
+  INTERNAL_ERROR: new PetraApiError(-30001, 'Internal Error', 'Internal Error'),
+  NO_ACCOUNTS: new PetraApiError(4000, 'No Accounts', 'No accounts found'),
+  TIME_OUT: new PetraApiError(
+    4002,
+    'Time Out',
+    'The prompt timed out without a response. This could be because the user did not respond or because a new request was opened.',
+  ),
+  UNAUTHORIZED: new PetraApiError(
+    4100,
+    'Unauthorized',
+    'The requested method and/or account has not been authorized by the user.',
+  ),
+  UNSUPPORTED: new PetraApiError(
+    4200,
+    'Unsupported',
+    'The provider does not support the requested method.',
+  ),
+  USER_REJECTION: new PetraApiError(
+    4001,
+    'Rejected',
+    'The user rejected the request',
+  ),
+});
+
+export function codeToError(code: number): PetraApiError {
+  return Object.values(PetraApiErrors)
+    .find((error) => error.code === code) ?? PetraApiErrors.INTERNAL_ERROR;
+}


### PR DESCRIPTION
The `message` property is not transported correctly from the Petra API.
Leveraging the `code` property and remapping errors on the Plugin side, to have full error support.