### PR TITLE
Use wallet-adapter-core as a normal dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "petra-plugin-wallet-adapter",
       "version": "0.4.4",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@aptos-labs/wallet-adapter-core": "^3.5.0"
+      },
       "devDependencies": {
         "@types/jest": "^29.2.3",
         "jest": "^29.3.1",
@@ -17,7 +20,6 @@
       },
       "peerDependencies": {
         "@aptos-labs/ts-sdk": "^1.3.0",
-        "@aptos-labs/wallet-adapter-core": "^3.5.0",
         "aptos": "^1.21.0"
       }
     },
@@ -69,7 +71,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-3.5.0.tgz",
       "integrity": "sha512-aA2kND9ikLOVx8yMS804S/atLZqmPe+Ldw/v9yG5osTHm+samv9H1NBha0rRGvArndeBcN4dGl9C/nc/SXyNcQ==",
-      "peer": true,
       "dependencies": {
         "buffer": "^6.0.3",
         "eventemitter3": "^4.0.7",
@@ -1612,8 +1613,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -1713,7 +1713,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -2235,8 +2234,7 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "peer": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -2614,8 +2612,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/ignore": {
       "version": "5.2.1",
@@ -4625,8 +4622,7 @@
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "peer": true
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "petra-plugin-wallet-adapter",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "petra-plugin-wallet-adapter",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/wallet-adapter-core": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petra-plugin-wallet-adapter",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Petra plugin to use with Aptos Wallet Adapter",
   "author": "Petra Aptos",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "build": "tsup src/index.ts --format esm,cjs --dts",
     "test": "jest"
   },
+  "dependencies": {
+    "@aptos-labs/wallet-adapter-core": "^3.5.0"
+  },
   "peerDependencies": {
     "aptos": "^1.21.0",
-    "@aptos-labs/ts-sdk": "^1.3.0",
-    "@aptos-labs/wallet-adapter-core": "^3.5.0"
+    "@aptos-labs/ts-sdk": "^1.3.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.3",


### PR DESCRIPTION
Using it as a peerDependency results in forcing dapps to install wallet-adapter-core as a dependency when they install Petra plugin